### PR TITLE
Add textile fold generative sketch

### DIFF
--- a/textile-flow-art.js
+++ b/textile-flow-art.js
@@ -1,41 +1,52 @@
-let params;
+let params = {
+  baseResolution: [3840, 2160], // 4K base
+  scale: 1, // 0.5 for 2K, 2 for 8K
+  strandCount: 100000,
+  strandLength: 180,
+  strandThickness: 0.5,
+  chunkSize: 1000,
+  macroNoiseScale: 0.002,
+  microNoiseScale: 0.03
+};
+
 let strands = [];
 let strandIndex = 0;
+let seed = 1;
 
 function setup() {
-  params = {
-    baseResolution: [3840, 2160], // default 4K
-    scale: 1,                     // 0.5 for 2K, 2 for 8K
-    strandCount: 50000,           // 50k strands
-    strandLength: 180,
-    strandThickness: 0.6,
-    turbulence: 0.0015,
-    chunkSize: 500,
-    colors: [
-      "#5B2C2C", "#8B3A3A", "#B26E63",
-      "#D9A441", "#4C8C8A", "#445B74",
-      "#8A7CA1", "#5B3E66", "#6E7D8C"
-    ]
-  };
+  createCanvas(
+    params.baseResolution[0] * params.scale,
+    params.baseResolution[1] * params.scale
+  );
+  colorMode(RGB);
+  noFill();
+  restartSketch();
+}
 
+function restartSketch() {
+  randomSeed(seed);
+  noiseSeed(seed);
   const w = params.baseResolution[0] * params.scale;
   const h = params.baseResolution[1] * params.scale;
-  createCanvas(w, h);
+  resizeCanvas(w, h);
 
-  colorMode(HSB, 360, 100, 100, 100);
-  noFill();
-
-  // Prepare strands
+  strands = [];
+  strandIndex = 0;
   for (let i = 0; i < params.strandCount; i++) {
     strands.push({ x: random(width), y: random(height) });
   }
 
-  background(20); // dark backdrop
+  background(20);
   drawGrid();
+  loop();
 }
 
 function draw() {
-  for (let i = 0; i < params.chunkSize && strandIndex < strands.length; i++, strandIndex++) {
+  for (
+    let i = 0;
+    i < params.chunkSize && strandIndex < strands.length;
+    i++, strandIndex++
+  ) {
     drawStrand(strands[strandIndex]);
   }
 
@@ -49,17 +60,26 @@ function drawStrand(s) {
   let y = s.y;
 
   for (let i = 0; i < params.strandLength; i++) {
-    const n = noise(x * params.turbulence, y * params.turbulence) * TWO_PI * 2;
-    const nx = x + cos(n) * 1.5;
-    const ny = y + sin(n) * 1.5;
+    const macro =
+      noise(x * params.macroNoiseScale, y * params.macroNoiseScale) * TWO_PI * 2;
+    const edgeDist = Math.min(width - x, x, height - y);
+    const edgeInfluence = constrain(
+      map(edgeDist, 0, height * 0.25, 1, 0),
+      0,
+      1
+    );
+    const edgeAngle = atan2(-y, width / 2 - x);
+    let angle = lerp(macro, edgeAngle, edgeInfluence);
+    angle +=
+      (noise(
+        x * params.microNoiseScale + 1000,
+        y * params.microNoiseScale + 1000
+      ) - 0.5) * 0.6;
 
-    // Color based on vertical position with band blending
-    const bandPos = constrain(map(y, 0, height, 0, params.colors.length - 1), 0, params.colors.length - 1);
-    const idx = floor(bandPos);
-    const frac = bandPos - idx;
-    const c1 = color(params.colors[idx]);
-    const c2 = color(params.colors[min(idx + 1, params.colors.length - 1)]);
-    stroke(lerpColor(c1, c2, frac));
+    const nx = x + cos(angle);
+    const ny = y + sin(angle);
+
+    stroke(getBandColor(y));
     strokeWeight(params.strandThickness);
     line(x, y, nx, ny);
 
@@ -68,19 +88,43 @@ function drawStrand(s) {
   }
 }
 
+function getBandColor(y) {
+  const h = height;
+  if (y < h / 3) {
+    const t = map(y, 0, h / 3, 0, 1);
+    return lerpColor(color("#7F1734"), color("#4B244A"), t); // Burgundy -> Plum
+  } else if (y < (2 * h) / 3) {
+    const t = map(y, h / 3, (2 * h) / 3, 0, 1);
+    return lerpColor(color("#008080"), color("#B8A1D1"), t); // Teal -> Lavender
+  } else {
+    const t = map(y, (2 * h) / 3, h, 0, 1);
+    return lerpColor(color("#D6C28B"), color("#6A7BA8"), t); // Faded Gold -> Slate Blue
+  }
+}
+
 function drawGrid() {
-  stroke(0, 0, 100, 3); // low opacity grid
+  stroke(255, 15);
   strokeWeight(1);
-  for (let x = 0; x <= width; x += 20) {
+  for (let x = 0; x <= width; x += 8) {
     line(x, 0, x, height);
   }
-  for (let y = 0; y <= height; y += 20) {
+  for (let y = 0; y <= height; y += 8) {
     line(0, y, width, y);
   }
 }
 
 function keyPressed() {
-  if (key === 's' || key === 'S') {
-    saveCanvas('textile-flow-art', 'png');
+  if (key === "s" || key === "S") {
+    saveCanvas("textile-flow-art", "png");
+  } else if (key === "1") {
+    params.scale = 0.5; // 2K
+    restartSketch();
+  } else if (key === "2") {
+    params.scale = 1; // 4K
+    restartSketch();
+  } else if (key === "3") {
+    params.scale = 2; // 8K
+    restartSketch();
   }
 }
+


### PR DESCRIPTION
## Summary
- Generate 100k curved textile strands with edge-influenced folds and dual noise fields
- Add muted color bands, woven grid, and high‑res export controls

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6891a2a232788330a63ae77870a6ee10